### PR TITLE
fix set-output deprecation

### DIFF
--- a/.github/workflows/reusable-docker-build.yaml
+++ b/.github/workflows/reusable-docker-build.yaml
@@ -199,4 +199,5 @@ jobs:
         id: ghcr-tag
         run: |
           echo '::echo::on'
-          echo "::set-output name=tag::gha-${{ github.run_id }}"
+          # shellcheck disable=SC2086
+          echo "tag=gha-${{ github.run_id }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixing this warning coming out of GHA runs:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/